### PR TITLE
add live assessment flag

### DIFF
--- a/.learn
+++ b/.learn
@@ -6,3 +6,4 @@ languages:
   - javascript
 resources:
   - 1
+live_assessment: true


### PR DESCRIPTION
Learn will not recognize this lesson as a Portfolio Project unless the .learn file contains this setting.