### PR TITLE
clarify requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ you don't have any inspiration at the moment, here are a couple of ideas:
 - There should be 3 routes
 - The Application must make use of `react-router` and proper RESTful routing (should you choose to use react-router v3 please refer to the appropriate [docs](https://github.com/ReactTraining/react-router/tree/v3/docs); docs for v4 can be found [here](https://reacttraining.com/react-router/web/guides/quick-start))
 - Use Redux middleware to respond to and modify state change
-- Make use of async actions and redux-thunk middleware to send data to and receive data from a server
+- Make use of async actions and `redux-thunk` middleware to send data to and receive data from a server
 - Your Rails API should handle the data persistence. You should be using `fetch()` within your actions to GET and POST data from your API - do not use
 jQuery methods.
 - Your client-side application should handle the display of data with minimal data manipulation

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ you don't have any inspiration at the moment, here are a couple of ideas:
 - There should be 3 routes
 - The Application must make use of `react-router` and proper RESTful routing (should you choose to use react-router v3 please refer to the appropriate [docs](https://github.com/ReactTraining/react-router/tree/v3/docs); docs for v4 can be found [here](https://reacttraining.com/react-router/web/guides/quick-start))
 - Use Redux middleware to respond to and modify state change
-- Make use of async actions to send data to and receive data from a server
+- Make use of async actions and redux-thunk middleware to send data to and receive data from a server
 - Your Rails API should handle the data persistence. You should be using `fetch()` within your actions to GET and POST data from your API - do not use
 jQuery methods.
 - Your client-side application should handle the display of data with minimal data manipulation


### PR DESCRIPTION
Addresses issue #8 

Add a simple line to clarify that `redux-thunk` must be used for all `fetch()` actions